### PR TITLE
fix: use 'master' instead of 'main' in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: pandoc to vimdoc
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v4
       - name: panvimdoc


### PR DESCRIPTION
The commit changes the branch reference in the GitHub actions CI workflow from
`main` to `master` to align with the new default branch naming convention. This
update ensures the CI workflow triggers correctly for the main branch.