### PR TITLE
Add install.sh script for development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,29 @@ wk.register({
 ```
 
 ## Development
-style-check with [style-lua](https://github.com/JohnnyMorganz/StyLua)
 
-testing with [vusted](https://github.com/notomo/vusted)
+### Development Environment Setup
 
+This project uses `stylua` for formatting Lua code and `vusted` for running tests.
+The `install.sh` script in the root of this repository will help you install these tools.
+
+**Prerequisites:**
+
+*   **Neovim:** Ensure you have Neovim installed. You can find installation instructions at [Installing Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim).
+*   **Rust/Cargo:** `stylua` is installed via Cargo. If you don't have Rust and Cargo, install them from [https://rustup.rs/](https://rustup.rs/).
+*   **Luarocks:** `vusted` is installed via Luarocks. If you don't have Luarocks, install it from [https://luarocks.org/wiki/rock/Installation](https://luarocks.org/wiki/rock/Installation).
+
+**Installation:**
+
+1.  Run the script:
+    ```sh
+    ./install.sh
+    ```
+    This will check for Cargo and Luarocks, then install `stylua` and `vusted`.
+
+### Running Tests
+
+After setting up the environment and installing `vusted`, you can run tests using:
 ```sh
 vusted ./test
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Starting development environment setup..."
+
+# Check for Cargo
+if ! command -v cargo &> /dev/null
+then
+    echo "Cargo not found. Please install Rust and Cargo from https://rustup.rs/"
+    exit 1
+fi
+
+echo "Installing stylua..."
+cargo install stylua
+
+# Check for Luarocks
+if ! command -v luarocks &> /dev/null
+then
+    echo "Luarocks not found. Please install Luarocks from https://luarocks.org/wiki/rock/Installation"
+    exit 1
+fi
+
+echo "Installing vusted..."
+luarocks install vusted
+
+echo "Development environment setup complete!"


### PR DESCRIPTION
This commit introduces an `install.sh` script to automate the
installation of development dependencies:
- stylua (via cargo)
- vusted (via luarocks)

The script checks if Cargo and Luarocks are installed and guides you
if they are missing.

The README.md has been updated to:
- Include a new "Development Environment Setup" section.
- Instruct you to run the `install.sh` script.
- List Neovim, Rust/Cargo, and Luarocks as prerequisites with links
  to their installation guides.