### PR TITLE
chore(ci): remove luajit job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           neovim: true
           version: nightly
 
+      - name: luajit
+        uses: leafo/gh-actions-lua@v11
+
       - name: luarocks
         uses: leafo/gh-actions-luarocks@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,6 @@ jobs:
           neovim: true
           version: nightly
 
-      - name: luajit
-        uses: leafo/gh-actions-lua@v11
-        with:
-          luaVersion: "luajit-openresty"
-
       - name: luarocks
         uses: leafo/gh-actions-luarocks@v5
 


### PR DESCRIPTION
Removing the luajit job simplifies the CI workflow, reducing build time and potential failure points. The project no longer requires luajit, streamlining the process for future development.