### PR TITLE
feat(test): add tests for subtractTime function

### DIFF
--- a/test/subtract_time_spec.lua
+++ b/test/subtract_time_spec.lua
@@ -40,19 +40,29 @@ describe('subtractTime', function()
         local year = os.date('%Y')
         local week = os.date('%W')
 
-        assert.is_not_nil(data.content.data[year][week].weekdays[weekday], 'Weekday data should exist')
-        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist')
-        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created')
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[weekday],
+            'Weekday data should exist'
+        )
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[weekday].items,
+            'Items should exist'
+        )
+        assert.are.same(
+            1,
+            #data.content.data[year][week].weekdays[weekday].items,
+            'One item should be created'
+        )
 
         local item = data.content.data[year][week].weekdays[weekday].items[1]
         assert(
-            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(item.diffInHours - -hoursToSubtract) < 0.001,
             'diffInHours should be approximately ' .. -hoursToSubtract
         )
 
         local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
         assert(
-            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(weekdaySummary.diffInHours - -hoursToSubtract) < 0.001,
             'Weekday summary diffInHours should be approximately ' .. -hoursToSubtract
         )
         assert(
@@ -78,18 +88,25 @@ describe('subtractTime', function()
         local year = os.date('%Y')
         local week = os.date('%W')
 
-        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Tuesday')
-        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created for Tuesday')
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[weekday].items,
+            'Items should exist for Tuesday'
+        )
+        assert.are.same(
+            1,
+            #data.content.data[year][week].weekdays[weekday].items,
+            'One item should be created for Tuesday'
+        )
 
         local item = data.content.data[year][week].weekdays[weekday].items[1]
         assert(
-            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(item.diffInHours - -hoursToSubtract) < 0.001,
             'diffInHours for Tuesday should be approximately ' .. -hoursToSubtract
         )
 
         local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
         assert(
-            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(weekdaySummary.diffInHours - -hoursToSubtract) < 0.001,
             'Tuesday summary diffInHours should be approximately ' .. -hoursToSubtract
         )
         assert(
@@ -107,7 +124,8 @@ describe('subtractTime', function()
     it('should subtract time from the current day if weekday is not provided', function()
         local hoursToSubtract = 1.5
         local currentWeekday = wdayToEngName[os.date('*t').wday]
-        local defaultHoursForCurrentDay = maorunTime.setup({ path = tempPath }).content.hoursPerWeekday[currentWeekday]
+        local defaultHoursForCurrentDay =
+            maorunTime.setup({ path = tempPath }).content.hoursPerWeekday[currentWeekday]
 
         maorunTime.subtractTime(hoursToSubtract) -- No weekday argument
         local data = maorunTime.calculate()
@@ -115,22 +133,30 @@ describe('subtractTime', function()
         local year = os.date('%Y')
         local week = os.date('%W')
 
-        assert.is_not_nil(data.content.data[year][week].weekdays[currentWeekday].items, 'Items should exist for current day')
-        assert.are.same(1, #data.content.data[year][week].weekdays[currentWeekday].items, 'One item should be created for current day')
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[currentWeekday].items,
+            'Items should exist for current day'
+        )
+        assert.are.same(
+            1,
+            #data.content.data[year][week].weekdays[currentWeekday].items,
+            'One item should be created for current day'
+        )
 
         local item = data.content.data[year][week].weekdays[currentWeekday].items[1]
         assert(
-            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(item.diffInHours - -hoursToSubtract) < 0.001,
             'diffInHours for current day should be approximately ' .. -hoursToSubtract
         )
 
         local weekdaySummary = data.content.data[year][week].weekdays[currentWeekday].summary
         assert(
-            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(weekdaySummary.diffInHours - -hoursToSubtract) < 0.001,
             'Current day summary diffInHours should be approximately ' .. -hoursToSubtract
         )
         assert(
-            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForCurrentDay)) < 0.001,
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForCurrentDay))
+                < 0.001,
             'Current day summary overhour calculation'
         )
 
@@ -155,22 +181,30 @@ describe('subtractTime', function()
         local year = os.date('%Y')
         local week = os.date('%W')
 
-        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Wednesday')
-        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created for Wednesday')
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[weekday].items,
+            'Items should exist for Wednesday'
+        )
+        assert.are.same(
+            1,
+            #data.content.data[year][week].weekdays[weekday].items,
+            'One item should be created for Wednesday'
+        )
 
         local item = data.content.data[year][week].weekdays[weekday].items[1]
         assert(
-            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(item.diffInHours - -hoursToSubtract) < 0.001,
             'diffInHours for Wednesday should be approximately ' .. -hoursToSubtract
         )
 
         local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
         assert(
-            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(weekdaySummary.diffInHours - -hoursToSubtract) < 0.001,
             'Wednesday summary diffInHours should be approximately ' .. -hoursToSubtract
         )
         assert(
-            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForWednesday)) < 0.001,
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForWednesday))
+                < 0.001,
             'Wednesday summary overhour calculation'
         )
 
@@ -194,8 +228,15 @@ describe('subtractTime', function()
         local year = os.date('%Y')
         local week = os.date('%W')
 
-        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Thursday')
-        assert.are.same(2, #data.content.data[year][week].weekdays[weekday].items, 'Two items should exist for Thursday (add and subtract)')
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[weekday].items,
+            'Items should exist for Thursday'
+        )
+        assert.are.same(
+            2,
+            #data.content.data[year][week].weekdays[weekday].items,
+            'Two items should exist for Thursday (add and subtract)'
+        )
 
         local totalDiffInHours = initialHours - hoursToSubtract
         local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
@@ -231,24 +272,34 @@ describe('subtractTime', function()
         local data = maorunTime.calculate()
         local year = os.date('%Y')
         local week = os.date('%W')
-        
+
         -- Check file content for paused state (optional, as isPaused() checks internal state)
         local file_content_raw = Path:new(tempPath):read()
         local file_content = vim.json.decode(file_content_raw)
-        assert.is_false(file_content.paused, "Paused state in data file should be false after resume")
+        assert.is_false(
+            file_content.paused,
+            'Paused state in data file should be false after resume'
+        )
 
-        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Friday')
-        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created for Friday despite pause/resume')
+        assert.is_not_nil(
+            data.content.data[year][week].weekdays[weekday].items,
+            'Items should exist for Friday'
+        )
+        assert.are.same(
+            1,
+            #data.content.data[year][week].weekdays[weekday].items,
+            'One item should be created for Friday despite pause/resume'
+        )
 
         local item = data.content.data[year][week].weekdays[weekday].items[1]
         assert(
-            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(item.diffInHours - -hoursToSubtract) < 0.001,
             'diffInHours for Friday should be approximately ' .. -hoursToSubtract
         )
 
         local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
         assert(
-            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            math.abs(weekdaySummary.diffInHours - -hoursToSubtract) < 0.001,
             'Friday summary diffInHours should be approximately ' .. -hoursToSubtract
         )
         assert(

--- a/test/subtract_time_spec.lua
+++ b/test/subtract_time_spec.lua
@@ -1,0 +1,265 @@
+local helper = require('test.helper')
+helper.plenary_dep()
+helper.notify_dep()
+
+local maorunTime = require('maorun.time')
+local os = require('os')
+local Path = require('plenary.path') -- Added for file manipulation
+local tempPath
+
+-- Copied from lua/maorun/time/init.lua for test purposes
+local wdayToEngName = {
+    [1] = 'Sunday',
+    [2] = 'Monday',
+    [3] = 'Tuesday',
+    [4] = 'Wednesday',
+    [5] = 'Thursday',
+    [6] = 'Friday',
+    [7] = 'Saturday',
+}
+
+before_each(function()
+    tempPath = os.tmpname()
+    -- Default setup, tests can override if specific hoursPerWeekday are needed
+    maorunTime.setup({ path = tempPath })
+end)
+
+after_each(function()
+    os.remove(tempPath)
+end)
+
+describe('subtractTime', function()
+    it('should subtract a whole number of hours from a specific weekday', function()
+        local weekday = 'Monday'
+        local hoursToSubtract = 3
+        local defaultHoursForMonday = 8 -- Assuming default config
+
+        maorunTime.subtractTime(hoursToSubtract, weekday)
+        local data = maorunTime.calculate()
+
+        local year = os.date('%Y')
+        local week = os.date('%W')
+
+        assert.is_not_nil(data.content.data[year][week].weekdays[weekday], 'Weekday data should exist')
+        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist')
+        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created')
+
+        local item = data.content.data[year][week].weekdays[weekday].items[1]
+        assert(
+            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            'diffInHours should be approximately ' .. -hoursToSubtract
+        )
+
+        local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
+        assert(
+            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            'Weekday summary diffInHours should be approximately ' .. -hoursToSubtract
+        )
+        assert(
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForMonday)) < 0.001,
+            'Weekday summary overhour should be ' .. (-hoursToSubtract - defaultHoursForMonday)
+        )
+
+        local weekSummary = data.content.data[year][week].summary
+        assert(
+            math.abs(weekSummary.overhour - (-hoursToSubtract - defaultHoursForMonday)) < 0.001,
+            'Week summary overhour should be ' .. (-hoursToSubtract - defaultHoursForMonday)
+        )
+    end)
+
+    it('should subtract fractional hours from a specific weekday', function()
+        local weekday = 'Tuesday'
+        local hoursToSubtract = 2.5
+        local defaultHoursForTuesday = 8 -- Assuming default config
+
+        maorunTime.subtractTime(hoursToSubtract, weekday)
+        local data = maorunTime.calculate()
+
+        local year = os.date('%Y')
+        local week = os.date('%W')
+
+        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Tuesday')
+        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created for Tuesday')
+
+        local item = data.content.data[year][week].weekdays[weekday].items[1]
+        assert(
+            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            'diffInHours for Tuesday should be approximately ' .. -hoursToSubtract
+        )
+
+        local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
+        assert(
+            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            'Tuesday summary diffInHours should be approximately ' .. -hoursToSubtract
+        )
+        assert(
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForTuesday)) < 0.001,
+            'Tuesday summary overhour should be ' .. (-hoursToSubtract - defaultHoursForTuesday)
+        )
+
+        local weekSummary = data.content.data[year][week].summary
+        assert(
+            math.abs(weekSummary.overhour - (-hoursToSubtract - defaultHoursForTuesday)) < 0.001,
+            'Week summary overhour should reflect Tuesday subtraction'
+        )
+    end)
+
+    it('should subtract time from the current day if weekday is not provided', function()
+        local hoursToSubtract = 1.5
+        local currentWeekday = wdayToEngName[os.date('*t').wday]
+        local defaultHoursForCurrentDay = maorunTime.setup({ path = tempPath }).content.hoursPerWeekday[currentWeekday]
+
+        maorunTime.subtractTime(hoursToSubtract) -- No weekday argument
+        local data = maorunTime.calculate()
+
+        local year = os.date('%Y')
+        local week = os.date('%W')
+
+        assert.is_not_nil(data.content.data[year][week].weekdays[currentWeekday].items, 'Items should exist for current day')
+        assert.are.same(1, #data.content.data[year][week].weekdays[currentWeekday].items, 'One item should be created for current day')
+
+        local item = data.content.data[year][week].weekdays[currentWeekday].items[1]
+        assert(
+            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            'diffInHours for current day should be approximately ' .. -hoursToSubtract
+        )
+
+        local weekdaySummary = data.content.data[year][week].weekdays[currentWeekday].summary
+        assert(
+            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            'Current day summary diffInHours should be approximately ' .. -hoursToSubtract
+        )
+        assert(
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForCurrentDay)) < 0.001,
+            'Current day summary overhour calculation'
+        )
+
+        local weekSummary = data.content.data[year][week].summary
+        assert(
+            math.abs(weekSummary.overhour - (-hoursToSubtract - defaultHoursForCurrentDay)) < 0.001,
+            'Week summary overhour should reflect current day subtraction'
+        )
+    end)
+
+    it('should correctly subtract time from a day with no prior entries', function()
+        local weekday = 'Wednesday'
+        local hoursToSubtract = 4
+        local defaultHoursForWednesday = 8 -- Assuming default config
+
+        -- Ensure no prior entries by re-initializing or checking count
+        -- before_each already sets up a clean state with no entries
+
+        maorunTime.subtractTime(hoursToSubtract, weekday)
+        local data = maorunTime.calculate()
+
+        local year = os.date('%Y')
+        local week = os.date('%W')
+
+        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Wednesday')
+        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created for Wednesday')
+
+        local item = data.content.data[year][week].weekdays[weekday].items[1]
+        assert(
+            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            'diffInHours for Wednesday should be approximately ' .. -hoursToSubtract
+        )
+
+        local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
+        assert(
+            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            'Wednesday summary diffInHours should be approximately ' .. -hoursToSubtract
+        )
+        assert(
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForWednesday)) < 0.001,
+            'Wednesday summary overhour calculation'
+        )
+
+        local weekSummary = data.content.data[year][week].summary
+        assert(
+            math.abs(weekSummary.overhour - (-hoursToSubtract - defaultHoursForWednesday)) < 0.001,
+            'Week summary overhour should reflect Wednesday subtraction'
+        )
+    end)
+
+    it('should correctly update summaries after subtraction and recalculation', function()
+        local weekday = 'Thursday'
+        local initialHours = 5
+        local hoursToSubtract = 2
+        local defaultHoursForThursday = 8 -- Assuming default config
+
+        maorunTime.addTime({ time = initialHours, weekday = weekday })
+        maorunTime.subtractTime(hoursToSubtract, weekday)
+        local data = maorunTime.calculate()
+
+        local year = os.date('%Y')
+        local week = os.date('%W')
+
+        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Thursday')
+        assert.are.same(2, #data.content.data[year][week].weekdays[weekday].items, 'Two items should exist for Thursday (add and subtract)')
+
+        local totalDiffInHours = initialHours - hoursToSubtract
+        local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
+        assert(
+            math.abs(weekdaySummary.diffInHours - totalDiffInHours) < 0.001,
+            'Thursday summary diffInHours should be ' .. totalDiffInHours
+        )
+        assert(
+            math.abs(weekdaySummary.overhour - (totalDiffInHours - defaultHoursForThursday)) < 0.001,
+            'Thursday summary overhour should be ' .. (totalDiffInHours - defaultHoursForThursday)
+        )
+
+        local weekSummary = data.content.data[year][week].summary
+        assert(
+            math.abs(weekSummary.overhour - (totalDiffInHours - defaultHoursForThursday)) < 0.001,
+            'Week summary overhour should reflect combined Thursday operations'
+        )
+    end)
+
+    it('should function correctly when time tracking is paused and resumed', function()
+        local weekday = 'Friday'
+        local hoursToSubtract = 1
+        local defaultHoursForFriday = 8 -- Assuming default config
+
+        maorunTime.TimePause()
+        assert.is_true(maorunTime.isPaused(), 'Time tracking should be paused')
+
+        maorunTime.subtractTime(hoursToSubtract, weekday)
+
+        maorunTime.TimeResume()
+        assert.is_false(maorunTime.isPaused(), 'Time tracking should be resumed')
+
+        local data = maorunTime.calculate()
+        local year = os.date('%Y')
+        local week = os.date('%W')
+        
+        -- Check file content for paused state (optional, as isPaused() checks internal state)
+        local file_content_raw = Path:new(tempPath):read()
+        local file_content = vim.json.decode(file_content_raw)
+        assert.is_false(file_content.paused, "Paused state in data file should be false after resume")
+
+        assert.is_not_nil(data.content.data[year][week].weekdays[weekday].items, 'Items should exist for Friday')
+        assert.are.same(1, #data.content.data[year][week].weekdays[weekday].items, 'One item should be created for Friday despite pause/resume')
+
+        local item = data.content.data[year][week].weekdays[weekday].items[1]
+        assert(
+            math.abs(item.diffInHours - (-hoursToSubtract)) < 0.001,
+            'diffInHours for Friday should be approximately ' .. -hoursToSubtract
+        )
+
+        local weekdaySummary = data.content.data[year][week].weekdays[weekday].summary
+        assert(
+            math.abs(weekdaySummary.diffInHours - (-hoursToSubtract)) < 0.001,
+            'Friday summary diffInHours should be approximately ' .. -hoursToSubtract
+        )
+        assert(
+            math.abs(weekdaySummary.overhour - (-hoursToSubtract - defaultHoursForFriday)) < 0.001,
+            'Friday summary overhour calculation'
+        )
+
+        local weekSummary = data.content.data[year][week].summary
+        assert(
+            math.abs(weekSummary.overhour - (-hoursToSubtract - defaultHoursForFriday)) < 0.001,
+            'Week summary overhour should reflect Friday subtraction'
+        )
+    end)
+end)


### PR DESCRIPTION
Adds a new test file `test/subtract_time_spec.lua` with comprehensive
test coverage for the `subtractTime` function in `lua/maorun/time/init.lua`.

The new test suite includes 6 test cases covering:
- Subtraction of whole and fractional hours.
- Defaulting to the current day when no weekday is specified.
- Subtraction from a day with no prior entries.
- Correct calculation of summaries after subtraction.
- Proper functionality with pause and resume states.

These tests ensure the reliability and correctness of the time
subtraction feature. No changes were made to your application code.
All existing and new tests pass.