### PR TITLE
feat: Add caching for Luarocks dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
         with:
           luaVersion: "luajit-openresty"
 
+      - name: Cache Luarocks
+        uses: actions/cache@v4
+        id: cache-luarocks
+        with:
+          path: ~/.luarocks
+          key: ${{ runner.os }}-luarocks-${{ hashFiles('**/rockspec') }}
+          restore-keys: |
+            ${{ runner.os }}-luarocks-
+
       - name: luarocks
         uses: leafo/gh-actions-luarocks@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,29 @@ jobs:
           neovim: true
           version: nightly
 
+      - name: Cache LuaJIT installation
+        uses: actions/cache@v4
+        id: cache-luajit
+        with:
+          path: .lua/
+          key: ${{ runner.os }}-luajit-openresty
+          restore-keys: |
+            ${{ runner.os }}-luajit-openresty
+
       - name: luajit
         uses: leafo/gh-actions-lua@v11
+        if: steps.cache-luajit.outputs.cache-hit != 'true'
         with:
           luaVersion: "luajit-openresty"
 
-      - name: Cache Luarocks
+      - name: Cache Luarocks packages
         uses: actions/cache@v4
         id: cache-luarocks
         with:
           path: ~/.luarocks
-          key: ${{ runner.os }}-luarocks-${{ hashFiles('**/rockspec') }}
+          key: ${{ runner.os }}-luajit-openresty-luarocks-${{ hashFiles('**/rockspec') }}
           restore-keys: |
-            ${{ runner.os }}-luarocks-
+            ${{ runner.os }}-luajit-openresty-luarocks-
 
       - name: luarocks
         uses: leafo/gh-actions-luarocks@v5


### PR DESCRIPTION
This change introduces caching for Luarocks dependencies in the GitHub Actions
workflow (`.github/workflows/ci.yml`).

The cache is configured to store the `~/.luarocks` directory, keyed by the
runner OS and a hash of any `rockspec` files found. This should help
speed up checks by avoiding repeated downloads and installations
of Luarocks packages like `luacheck` and `vusted`.