### PR TITLE
Fix: Use --local for luarocks vusted installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,6 @@ then
 fi
 
 echo "Installing vusted..."
-luarocks install vusted
+luarocks install --local vusted
 
 echo "Development environment setup complete!"


### PR DESCRIPTION
This change addresses an error where `luarocks install vusted` would fail due to permission issues when trying to write to global directories.
By adding the `--local` flag, `vusted` will be installed in your local Luarocks tree (~/.luarocks), which does not require elevated privileges and resolves the permission error.