### PR TITLE
docs: Update development setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,22 @@ wk.register({
 
 ### Development Environment Setup
 
-This project uses `stylua` for formatting Lua code and `vusted` for running tests.
-The `install.sh` script in the root of this repository will help you install these tools.
+This project uses `stylua` for formatting and `vusted` for testing. The `install.sh` script helps install these tools using Luarocks. The script also attempts to install necessary dependencies like Luarocks if they are missing (on supported systems like Linux/macOS).
 
 **Prerequisites:**
 
 *   **Neovim:** Ensure you have Neovim installed. You can find installation instructions at [Installing Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim).
-*   **Rust/Cargo:** `stylua` is installed via Cargo. If you don't have Rust and Cargo, install them from [https://rustup.rs/](https://rustup.rs/).
-*   **Luarocks:** `vusted` is installed via Luarocks. If you don't have Luarocks, install it from [https://luarocks.org/wiki/rock/Installation](https://luarocks.org/wiki/rock/Installation).
+*   **Luarocks:** Used for installing `vusted` and `stylua`. The `install.sh` script will attempt to install Luarocks if it's not found on your system (for Linux and macOS). For other operating systems, or if the automatic installation fails, you might need to install it manually from [https://luarocks.org/wiki/rock/Installation](https://luarocks.org/wiki/rock/Installation).
 
 **Installation:**
+
+**For Windows users:** The `install.sh` script is primarily designed for Linux and macOS. If you run it on Windows, it will detect the OS and print a message with guidance for manual installation of Luarocks and the other development dependencies, as automatic installation is not supported for Windows via this script.
 
 1.  Run the script:
     ```sh
     ./install.sh
     ```
-    This will check for Cargo and Luarocks, then install `stylua` and `vusted`.
+    This will check for Luarocks and then install `stylua` and `vusted`.
 
 ### Running Tests
 


### PR DESCRIPTION
The Development section in README.md has been updated to accurately
reflect the behavior of the `install.sh` script.

Key changes:
- Clarified that `install.sh` attempts to automatically install Luarocks
  on Linux and macOS if it's not already present.
- Corrected the installation method for `stylua` to show it's installed
  via Luarocks by the script, not Cargo. The Rust/Cargo prerequisite
  has been removed accordingly.
- Added a note for Windows users, explaining that `install.sh` will
  detect their OS and provide guidance for manual installation of
  dependencies, as the script does not support automatic installation
  on Windows.
- Ensured overall clarity and logical flow of the development setup
  instructions.