### PR TITLE
Fix: Update CI workflow to use Lua 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,29 +32,29 @@ jobs:
           neovim: true
           version: nightly
 
-      - name: Cache LuaJIT installation
+      - name: Cache Lua installation
         uses: actions/cache@v4
         id: cache-luajit
         with:
           path: .lua/
-          key: ${{ runner.os }}-luajit-openresty
+          key: ${{ runner.os }}-lua-5.1
           restore-keys: |
-            ${{ runner.os }}-luajit-openresty
+            ${{ runner.os }}-lua-5.1
 
-      - name: luajit
+      - name: Setup Lua
         uses: leafo/gh-actions-lua@v11
         if: steps.cache-luajit.outputs.cache-hit != 'true'
         with:
-          luaVersion: "luajit-openresty"
+          luaVersion: "5.1"
 
       - name: Cache Luarocks packages
         uses: actions/cache@v4
         id: cache-luarocks
         with:
           path: ~/.luarocks
-          key: ${{ runner.os }}-luajit-openresty-luarocks-${{ hashFiles('**/rockspec') }}
+          key: ${{ runner.os }}-lua-5.1-luarocks-${{ hashFiles('**/rockspec') }}
           restore-keys: |
-            ${{ runner.os }}-luajit-openresty-luarocks-
+            ${{ runner.os }}-lua-5.1-luarocks-
 
       - name: luarocks
         uses: leafo/gh-actions-luarocks@v5


### PR DESCRIPTION
Changes the CI workflow to use Lua version 5.1 instead of luajit-openresty.
This also involves updating the cache keys and renaming the relevant steps
to reflect the change in Lua version.

- Updated Lua version to 5.1 in the setup step.
- Modified cache keys for Lua installation and Luarocks packages.
- Renamed "Cache LuaJIT installation" to "Cache Lua installation".
- Renamed "luajit" step to "Setup Lua".