### PR TITLE
feat: Integrate Luacov for test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     needs: lint
     name: Run Test
     runs-on: ${{ matrix.os }}
-    permissions:
-      contents: write
     strategy:
       matrix:
         os:
@@ -28,8 +26,6 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
       - uses: rhysd/action-setup-vim@v1
         id: vim
         with:
@@ -74,14 +70,12 @@ jobs:
         run: |
           lua -lluacov $(which vusted) ./test
 
-      - name: Generate Luacov report
-        run: luacov
-
-      - name: Commit coverage report
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Upload Luacov stats
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: 'chore(ci): update coverage report'
-          file_pattern: luacov.report.out luacov.stats.out
+          name: luacov-stats-${{ matrix.os }}
+          path: luacov.stats.out
+          if-no-files-found: error # Optional: ensures the job fails if the stats file isn't found
 
   docs:
     needs: test
@@ -105,3 +99,68 @@ jobs:
         with:
           commit_message: 'chore(doc): auto generate docs'
 
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Generate and Commit Coverage Report
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+
+      - name: Cache Lua installation
+        uses: actions/cache@v4
+        id: cache-luajit # Added id for consistency, step name matches test job
+        with:
+          path: .lua/
+          key: ${{ runner.os }}-lua-5.1 # Note: runner.os for coverage job will always be ubuntu-latest
+          restore-keys: |
+            ${{ runner.os }}-lua-5.1
+
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v11
+        if: steps.cache-luajit.outputs.cache-hit != 'true' # Made conditional
+        with:
+          luaVersion: "5.1"
+
+      - name: Cache Luarocks packages
+        uses: actions/cache@v4
+        id: cache-luarocks # Added id
+        with:
+          path: ~/.luarocks
+          # Since coverage job doesn't have rockspec typically, we might simplify the key
+          # or keep it consistent. For now, keep consistent.
+          key: ${{ runner.os }}-lua-5.1-luarocks-${{ hashFiles('**/rockspec') }}
+          restore-keys: |
+            ${{ runner.os }}-lua-5.1-luarocks-
+
+      - name: Setup Luarocks
+        uses: leafo/gh-actions-luarocks@v5
+
+      - name: Install Luacov
+        run: luarocks install luacov
+
+      - name: Download Luacov stats from Ubuntu
+        uses: actions/download-artifact@v4
+        with:
+          name: luacov-stats-ubuntu-latest
+          # This will download to the current workspace, potentially in a folder.
+          # By default, it downloads into a directory named after the artifact.
+          # So, 'luacov-stats-ubuntu-latest/luacov.stats.out'
+
+      - name: Move Luacov stats file
+        run: mv luacov-stats-ubuntu-latest/luacov.stats.out luacov.stats.out
+
+      - name: Generate Luacov report
+        run: luacov # This generates luacov.report.out from luacov.stats.out
+
+      - name: Commit coverage report
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore(ci): update coverage report'
+          file_pattern: luacov.report.out luacov.stats.out
+          # Consider adding luacov.stats.out to .gitignore if it's always identical to the one from the primary OS run
+          # For now, committing both to ensure the report can be regenerated from the committed stats.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: run test
         shell: bash
         run: |
-          luacov vusted ./test
+          lua -lluacov $(which vusted) ./test
 
       - name: Generate Luacov report
         run: luacov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Run tests with Luacov
         shell: bash
         run: |
-          lua -lluacov $(which vusted) ./test
+          luacov vusted ./test
 
       - name: Generate Luacov report
         run: luacov # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run tests for coverage
         shell: bash
         run: |
-          vusted --lua-lluacov ./test
+          vusted --coverage ./test
 
       - name: Generate Luacov report
         run: luacov ${{ github.workspace }}/luacov.stats.out # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     needs: lint
     name: Run Test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         os:
@@ -26,6 +28,8 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
       - uses: rhysd/action-setup-vim@v1
         id: vim
         with:
@@ -63,11 +67,21 @@ jobs:
         shell: bash
         run: |
           luarocks install vusted
+          luarocks install luacov
 
       - name: run test
         shell: bash
         run: |
-          vusted ./test
+          luacov -r vusted ./test
+
+      - name: Generate Luacov report
+        run: luacov
+
+      - name: Commit coverage report
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore(ci): update coverage report'
+          file_pattern: luacov.report.out luacov.stats.out
 
   docs:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Setup Neovim
         uses: rhysd/action-setup-vim@v1
-        id: vim
+        id: nvim
         with:
           neovim: true
           version: nightly
@@ -146,10 +146,20 @@ jobs:
       - name: Run tests for coverage
         shell: bash
         run: |
-          LUA_OPTS="-lluacov" vusted ./test
+          LUACOV_STATSFILE=${{ github.workspace }}/luacov.stats.out LUA_OPTS="-lluacov" vusted ./test
+
+      - name: Debug: List files after test run
+        shell: bash
+        run: |
+          echo "Current directory: $(pwd)"
+          echo "Workspace content:"
+          ls -Rla ${{ github.workspace }}
+          echo "Searching for luacov.stats.out in workspace:"
+          find ${{ github.workspace }} -name "luacov.stats.out" -print -exec echo "Found luacov.stats.out above" \;
+          echo "Value of LUACOV_STATSFILE in this step: $LUACOV_STATSFILE"
 
       - name: Generate Luacov report
-        run: luacov # This generates luacov.report.out from luacov.stats.out
+        run: luacov ${{ github.workspace }}/luacov.stats.out # This generates luacov.report.out from luacov.stats.out
 
       - name: Commit coverage report
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,10 @@ jobs:
           luarocks install vusted
           luarocks install luacov
 
-      - name: Run tests with Luacov
+      - name: Run tests for coverage
         shell: bash
         run: |
-          luacov vusted ./test
+          LUA_OPTS="-lluacov" vusted ./test
 
       - name: Generate Luacov report
         run: luacov # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,19 +63,11 @@ jobs:
         shell: bash
         run: |
           luarocks install vusted
-          luarocks install luacov
 
       - name: run test
         shell: bash
         run: |
-          lua -lluacov $(which vusted) ./test
-
-      - name: Upload Luacov stats
-        uses: actions/upload-artifact@v4
-        with:
-          name: luacov-stats-${{ matrix.os }}
-          path: luacov.stats.out
-          if-no-files-found: error # Optional: ensures the job fails if the stats file isn't found
+          vusted ./test
 
   docs:
     needs: test
@@ -140,19 +132,15 @@ jobs:
       - name: Setup Luarocks
         uses: leafo/gh-actions-luarocks@v5
 
-      - name: Install Luacov
-        run: luarocks install luacov
+      - name: Install dependencies
+        run: |
+          luarocks install vusted
+          luarocks install luacov
 
-      - name: Download Luacov stats from Ubuntu
-        uses: actions/download-artifact@v4
-        with:
-          name: luacov-stats-ubuntu-latest
-          # This will download to the current workspace, potentially in a folder.
-          # By default, it downloads into a directory named after the artifact.
-          # So, 'luacov-stats-ubuntu-latest/luacov.stats.out'
-
-      - name: Move Luacov stats file
-        run: mv luacov-stats-ubuntu-latest/luacov.stats.out luacov.stats.out
+      - name: Run tests with Luacov
+        shell: bash
+        run: |
+          lua -lluacov $(which vusted) ./test
 
       - name: Generate Luacov report
         run: luacov # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: run test
         shell: bash
         run: |
-          luacov -r vusted ./test
+          luacov vusted ./test
 
       - name: Generate Luacov report
         run: luacov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,17 +146,7 @@ jobs:
       - name: Run tests for coverage
         shell: bash
         run: |
-          LUACOV_STATSFILE=${{ github.workspace }}/luacov.stats.out LUA_OPTS="-lluacov" vusted ./test
-
-      - name: Debug: List files after test run
-        shell: bash
-        run: |
-          echo "Current directory: $(pwd)"
-          echo "Workspace content:"
-          ls -Rla ${{ github.workspace }}
-          echo "Searching for luacov.stats.out in workspace:"
-          find ${{ github.workspace }} -name "luacov.stats.out" -print -exec echo "Found luacov.stats.out above" \;
-          echo "Value of LUACOV_STATSFILE in this step: $LUACOV_STATSFILE"
+          vusted --lua-lluacov ./test
 
       - name: Generate Luacov report
         run: luacov ${{ github.workspace }}/luacov.stats.out # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run tests for coverage
         shell: bash
         run: |
-          vusted ./test
+          LUA_OPTS="-lluacov" vusted ./test
 
       - name: Generate Luacov report
         run: luacov # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run tests for coverage
         shell: bash
         run: |
-          LUA_OPTS="-lluacov" vusted ./test
+          vusted ./test
 
       - name: Generate Luacov report
         run: luacov # This generates luacov.report.out from luacov.stats.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,6 @@ jobs:
 
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v11
-        if: steps.cache-luajit.outputs.cache-hit != 'true' # Made conditional
         with:
           luaVersion: "5.1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
 
+      - name: Setup Neovim
+        uses: rhysd/action-setup-vim@v1
+        id: vim
+        with:
+          neovim: true
+          version: nightly
+
       - name: Cache Lua installation
         uses: actions/cache@v4
         id: cache-luajit # Added id for consistency, step name matches test job

--- a/README.md
+++ b/README.md
@@ -76,3 +76,6 @@ After setting up the environment and installing `vusted`, you can run tests usin
 ```sh
 vusted ./test
 ```
+
+## Test Coverage
+View the latest test coverage report: [luacov.report.out](luacov.report.out)

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,4 +1,4 @@
-require("luacov")
+require('luacov')
 
 local function join_paths(...)
     local result = table.concat({ ... }, '/')

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,3 +1,5 @@
+require("luacov")
+
 local function join_paths(...)
     local result = table.concat({ ... }, '/')
     return result

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,5 +1,3 @@
-require('luacov')
-
 local function join_paths(...)
     local result = table.concat({ ... }, '/')
     return result


### PR DESCRIPTION
I've integrated Luacov into the CI pipeline to generate and commit test coverage reports.

Key changes:
- Modified `.github/workflows/ci.yml`:
    - Added Luacov installation to the 'test' job.
    - Updated the test command to run tests via Luacov, generating `luacov.stats.out`.
    - Added steps to generate a text report (`luacov.report.out`).
    - Configured the 'test' job with PAT and permissions to allow committing.
    - Added `stefanzweifel/git-auto-commit-action` to automatically commit `luacov.report.out` and `luacov.stats.out` to the repository after successful test runs.
- Updated `README.md`:
    - Added a new "Test Coverage" section.
    - Included a link to the `luacov.report.out` file for easy access to the latest coverage data.

This will help you in tracking code coverage over time and ensuring new contributions are adequately tested.