### PR TITLE
fix(ci): Specify explicit paths for luacov files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,10 @@ jobs:
       - name: Run tests for coverage
         shell: bash
         run: |
-          LUA_OPTS="-lluacov" vusted ./test
+          LUACOV_STATSFILE=${{ github.workspace }}/luacov.stats.out LUA_OPTS="-lluacov" vusted ./test
 
       - name: Generate Luacov report
-        run: luacov # This generates luacov.report.out from luacov.stats.out
+        run: luacov ${{ github.workspace }}/luacov.stats.out # This generates luacov.report.out from luacov.stats.out
 
       - name: Commit coverage report
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
The 'generate luacov report' CI step was failing with an error:
'Could not load stats file /home/runner/work/timeTrack.nvim/timeTrack.nvim/luacov.stats.out.'

This commit addresses the issue by:
1. Setting the `LUACOV_STATSFILE` environment variable to `${{ github.workspace }}/luacov.stats.out` during the test execution step (`Run tests for coverage`). This ensures Luacov (loaded via `LUA_OPTS="-lluacov"`) writes its statistics file to a known, absolute path in the workspace root.
2. Modifying the `luacov` command in the `Generate Luacov report` step to explicitly read from `${{ github.workspace }}/luacov.stats.out`.

These changes ensure that the Luacov statistics file is generated and read from a consistent and explicit location, resolving the 'file not found' error. The `file_pattern` for committing the report was verified to be correct as the files are now in the workspace root.