### PR TITLE
feat: auto-format Lua code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Stylua
@@ -12,7 +14,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          args: --check .
+      - name: Auto Commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'style: auto format Lua code'
 
 
   test:


### PR DESCRIPTION
Modifies the CI workflow to automatically format Lua code using Stylua and commit the changes.

Previously, the CI only checked for formatting issues. This change updates the `lint` job to:
- Run `stylua` to format the code in place.
- Use the `stefanzweifel/git-auto-commit-action` to commit any formatting changes with the message "style: auto format Lua code".