### PR TITLE
CI: Install inspect module for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         shell: bash
         run: |
           luarocks install vusted
+          luarocks install inspect
 
       - name: run test
         shell: bash


### PR DESCRIPTION
The 'inspect' Lua module is a dependency for running your test suite,
as it's used for generating debug information in test assertions.

This change updates the GitHub Actions workflow to install 'inspect'
via LuaRocks during the test job setup. This ensures that the CI
environment has all necessary dependencies to execute the tests
successfully.