### PR TITLE
fix(ci): Improve reliability of coverage report processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Generate Luacov report
         run: luacov -c .luacov
 
+      - name: Flush filesystem buffers
+        run: sync
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/update_readme_coverage.py
+++ b/update_readme_coverage.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+import time
 
 def read_file_content(filepath):
     """Reads the content of a file.
@@ -135,17 +136,51 @@ def main():
     luacov_report_path = "luacov.report.out"
     readme_path = "README.md"
 
-    report_content = read_file_content(luacov_report_path)
-    if report_content is None:
+    report_content = None
+    summary_table = None
+    max_retries = 3
+    retry_delay_seconds = 2
+
+    for attempt in range(max_retries):
+        print(f"Attempt {attempt + 1} to read and parse {luacov_report_path}...", file=sys.stderr)
+        current_report_content = read_file_content(luacov_report_path)
+        if current_report_content:
+            report_content = current_report_content # Store last successful read
+            current_summary_table = extract_summary_from_report(report_content)
+            if current_summary_table and current_summary_table.strip():
+                summary_table = current_summary_table
+                print(f"Successfully parsed summary on attempt {attempt + 1}.", file=sys.stderr)
+                break  # Success
+            else:
+                # Summary found but it's empty, or extract_summary_from_report returned None (and printed an error)
+                if current_summary_table is None:
+                    # extract_summary_from_report already printed its error
+                    pass
+                elif not current_summary_table.strip():
+                    print(f"Warning: Extracted summary was empty on attempt {attempt + 1}.", file=sys.stderr)
+                summary_table = None # Ensure summary_table is None if strip check fails
+        else:
+            # read_file_content already printed its error
+            report_content = None # Ensure report_content is None if read fails
+
+        if attempt < max_retries - 1:
+            print(f"Attempt {attempt + 1} failed. Retrying in {retry_delay_seconds} seconds...", file=sys.stderr)
+            time.sleep(retry_delay_seconds)
+        else:
+            print(f"All {max_retries} attempts to read or parse {luacov_report_path} failed.", file=sys.stderr)
+
+    if not report_content: # Handles case where file itself was never read successfully
+        # Error already printed by read_file_content or loop
         sys.exit(1)
 
-    summary_table = extract_summary_from_report(report_content)
-    if summary_table is None:
+    if not summary_table: # Handles case where summary was never extracted or was empty after all retries
+        # Error already printed by extract_summary_from_report or loop
         sys.exit(1)
 
-    # Ensure summary_table is not empty after stripping
-    if not summary_table.strip():
-        print("Error: Extracted summary table is empty after stripping. Cannot update README.", file=sys.stderr)
+    # This check is now more of a safeguard, as the loop should ensure summary_table is valid and stripped.
+    # However, keeping it doesn't hurt.
+    if not summary_table.strip(): # Should have been caught by the loop's `if current_summary_table and current_summary_table.strip():`
+        print("Error: Extracted summary table is empty after stripping (final check). Cannot update README.", file=sys.stderr)
         sys.exit(1)
 
     readme_content = read_file_content(readme_path)


### PR DESCRIPTION
The Python script `update_readme_coverage.py` sometimes failed in CI
with "Error: Summary section start not found in luacov.report.out".
This was likely due to the script attempting to read the report file
before `luacov` had finished writing it.

This commit addresses the issue in two ways:

1.  The `update_readme_coverage.py` script has been updated to
    retry reading and parsing `luacov.report.out` up to 3 times
    with a 2-second delay between attempts. This makes the script
    more resilient to transient file access issues.

2.  The CI workflow (`.github/workflows/ci.yml`) has been modified
    to include a `sync` command after generating the luacov report
    and before the Python script runs. This helps ensure that the
    report file's contents are fully flushed to disk.

These changes together should make the coverage processing step in CI
more robust and prevent the previously observed error.