### PR TITLE
refactor(ci): consolidate auto-commit jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: .
-      - name: Auto Commit
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Upload formatted code artifact
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: 'style: auto format Lua code'
-
+          name: formatted-code
+          path: .
 
   test:
     needs: lint
@@ -94,9 +94,11 @@ jobs:
         with:
           vimdoc: timeTrack.nvim
           treesitter: true
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: 'chore(doc): auto generate docs'
+          name: documentation
+          path: .
 
   coverage:
     needs: test
@@ -168,11 +170,87 @@ jobs:
 
       - name: Generate Luacov report
         run: luacov -c .luacov
-
-      - name: Commit coverage report
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: 'chore(ci): update coverage report [skip ci]'
-          file_pattern: luacov.report.out luacov.stats.out
-          # Consider adding luacov.stats.out to .gitignore if it's always identical to the one from the primary OS run
-          # For now, committing both to ensure the report can be regenerated from the committed stats.
+          name: coverage-files
+          path: |
+            luacov.report.out
+            luacov.stats.out
+
+consolidate-and-commit:
+  runs-on: ubuntu-latest
+  needs: [lint, docs, coverage]
+  if: ${{ !cancelled() }} # Run unless the whole workflow was cancelled
+  permissions:
+    contents: write
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.PAT }} # Use PAT for potential push to protected branches
+        ref: ${{ github.head_ref || github.ref }} # Checkout the appropriate branch/PR head
+
+    - name: Download formatted code
+      uses: actions/download-artifact@v4
+      with:
+        name: formatted-code
+        path: temp_lint
+      continue-on-error: true
+
+    - name: Download documentation
+      uses: actions/download-artifact@v4
+      with:
+        name: documentation
+        path: temp_docs
+      continue-on-error: true
+
+    - name: Download coverage files
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage-files
+        path: temp_coverage
+      continue-on-error: true
+
+    - name: Apply changes from artifacts
+      run: |
+        set -e # Exit immediately if a command exits with a non-zero status.
+        echo "Applying changes from artifacts..."
+
+        if [ -d "temp_lint" ] && [ "$(ls -A temp_lint)" ]; then
+          echo "Applying linted files..."
+          rsync -av --delete --exclude='.git/' temp_lint/ ./
+        else
+          echo "Lint artifact not found or is empty."
+        fi
+
+        if [ -d "temp_docs" ] && [ "$(ls -A temp_docs)" ]; then
+          echo "Applying documentation files..."
+          rsync -av --delete --exclude='.git/' temp_docs/ ./
+        else
+          echo "Documentation artifact not found or is empty."
+        fi
+
+        if [ -d "temp_coverage" ] && [ "$(ls -A temp_coverage)" ]; then
+          echo "Applying coverage files..."
+          cp -R temp_coverage/* ./
+        else
+          echo "Coverage artifact not found or is empty."
+        fi
+
+        echo "Cleaning up temporary artifact directories..."
+        rm -rf temp_lint temp_docs temp_coverage
+
+        echo "Current git status:"
+        git status
+      shell: bash
+
+    - name: Commit consolidated changes
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: 'chore(ci): auto-generated changes from CI'
+        token: ${{ secrets.PAT }} # Use PAT for commit/push
+        commit_user_name: 'github-actions[bot]'
+        commit_user_email: 'github-actions[bot]@users.noreply.github.com'
+        commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+        # No file_pattern is needed; the action commits all detected changes by default.


### PR DESCRIPTION
 consolidated the three separate auto-commit steps in the CI workflow
into a single job that runs at the end.

Previously, auto-commits were performed individually after linting,
documentation generation, and coverage reporting.

This change introduces the following:
- The `lint`, `docs`, and `coverage` jobs now upload their respective
  outputs (formatted code, generated documentation, coverage reports)
  as artifacts.
- I added a new job, `consolidate-and-commit`, which runs after
  the aforementioned jobs.
- This new job downloads the artifacts, applies all changes to the
  workspace (linting changes first, then documentation, then coverage),
  and then performs a single auto-commit with all accumulated changes.
- The commit message for this consolidated commit is
  'chore(ci): auto-generated changes from CI'.

This approach centralizes the auto-commit logic, making the CI
workflow cleaner and ensuring that all automated changes are grouped
into one commit.