### PR TITLE
Fix: Ensure time tracking stops consistently and refactor plugin loading

### DIFF
--- a/lua/maorun/time/autocmds.lua
+++ b/lua/maorun/time/autocmds.lua
@@ -63,6 +63,26 @@ function M.setup_autocmds()
         end,
     })
 
+    vim.api.nvim_create_autocmd('FocusLost', {
+        group = timeGroup,
+        desc = 'Stop Timetracking when Neovim loses focus',
+        callback = function()
+            local current_buf = vim.api.nvim_get_current_buf()
+            local bufname = vim.api.nvim_buf_get_name(current_buf)
+            -- Similar check for empty or special buffers
+            if bufname == '' or vim.bo[current_buf].buftype ~= '' then
+                return
+            end
+
+            local info = utils.get_project_and_file_info(current_buf)
+            if info then
+                core.TimeStop({ project = info.project, file = info.file })
+            else
+                core.TimeStop()
+            end
+        end,
+    })
+
     vim.api.nvim_create_autocmd('BufLeave', {
         group = timeGroup,
         desc = 'Stop Timetracking for the buffer being left',


### PR DESCRIPTION
This commit addresses the issue where time tracking would sometimes not stop as expected. It also refactors how the plugin's autocommands are loaded based on your feedback.

Changes:

- Removed `plugin/timeTrack.nvim.lua` as it was redundant. Autocommand setup is handled within the `lua/maorun/time/init.lua` file's `setup` function, which calls `autocmds.setup_autocmds()`.
- Added a `FocusLost` autocommand to `lua/maorun/time/autocmds.lua`. This ensures that time tracking stops when Neovim loses focus, covering a scenario where tracking might have unintentionally continued.
- Verified that the `FocusLost` autocommand is not duplicated in `lua/maorun/time/init.lua`.

These changes should lead to more reliable and consistent behavior for stopping time tracking.