### PR TITLE
Fix: Correctly replace coverage summary in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,17 +190,3 @@ File                                                                         Hit
 -------------------------------------------------------------------------------------------------
 Total                                                                        462  107    81.20%
 ```
-
-```markdown
-File                                                                         Hits Missed Coverage
--------------------------------------------------------------------------------------------------
-/home/runner/nvim-nightly/share/nvim/runtime/lua/vim/ui.lua                  6    80     6.98%
-/home/runner/work/timeTrack.nvim/timeTrack.nvim/lua/maorun/time/autocmds.lua 16   28     36.36%
-/home/runner/work/timeTrack.nvim/timeTrack.nvim/lua/maorun/time/config.lua   17   0      100.00%
-/home/runner/work/timeTrack.nvim/timeTrack.nvim/lua/maorun/time/core.lua     315  19     94.31%
-/home/runner/work/timeTrack.nvim/timeTrack.nvim/lua/maorun/time/init.lua     34   32     51.52%
-/home/runner/work/timeTrack.nvim/timeTrack.nvim/lua/maorun/time/ui.lua       31   24     56.36%
-/home/runner/work/timeTrack.nvim/timeTrack.nvim/lua/maorun/time/utils.lua    15   35     30.00%
--------------------------------------------------------------------------------------------------
-Total                                                                        434  218    66.56%
-```


### PR DESCRIPTION
The update_readme_coverage.py script was updated to properly handle cases where the README.md file might have multiple consecutive markdown blocks for the coverage summary under the "The latest summary is:" line.

The script's regular expression was modified to match the target line followed by one or more markdown blocks, ensuring that all such consecutive blocks are consumed and replaced by a single, new, updated coverage summary. This resolves the issue of duplicated coverage summaries accumulating in the README.md file.