### PR TITLE
refactor: remove buffer checks in autocmds

### DIFF
--- a/lua/maorun/time/autocmds.lua
+++ b/lua/maorun/time/autocmds.lua
@@ -24,20 +24,10 @@ function M.setup_autocmds()
         group = timeGroup,
         desc = 'Start Timetracking when entering a buffer',
         callback = function(args)
-            -- Prevent execution if buffer name is empty (e.g. new empty buffer)
-            -- or if it's a special buffer like Telescope prompt
-            local bufname = vim.api.nvim_buf_get_name(args.buf)
-            if bufname == '' or vim.bo[args.buf].buftype ~= '' then
-                return
-            end
-
             local info = utils.get_project_and_file_info(args.buf)
             if info then
                 core.TimeStart({ project = info.project, file = info.file })
             else
-                -- It's possible that even with a valid bufname, info is nil
-                -- if get_project_and_file_info can't determine project/file.
-                -- In this case, using defaults is reasonable.
                 core.TimeStart()
             end
         end,
@@ -48,12 +38,6 @@ function M.setup_autocmds()
         desc = 'Start Timetracking when Neovim gains focus',
         callback = function()
             local current_buf = vim.api.nvim_get_current_buf()
-            local bufname = vim.api.nvim_buf_get_name(current_buf)
-            -- Similar check for empty or special buffers
-            if bufname == '' or vim.bo[current_buf].buftype ~= '' then
-                return
-            end
-
             local info = utils.get_project_and_file_info(current_buf)
             if info then
                 core.TimeStart({ project = info.project, file = info.file })
@@ -68,12 +52,6 @@ function M.setup_autocmds()
         desc = 'Stop Timetracking when Neovim loses focus',
         callback = function()
             local current_buf = vim.api.nvim_get_current_buf()
-            local bufname = vim.api.nvim_buf_get_name(current_buf)
-            -- Similar check for empty or special buffers
-            if bufname == '' or vim.bo[current_buf].buftype ~= '' then
-                return
-            end
-
             local info = utils.get_project_and_file_info(current_buf)
             if info then
                 core.TimeStop({ project = info.project, file = info.file })
@@ -87,12 +65,6 @@ function M.setup_autocmds()
         group = timeGroup,
         desc = 'Stop Timetracking for the buffer being left',
         callback = function(args)
-            -- Prevent execution if buffer name is empty or special buffer
-            local bufname = vim.api.nvim_buf_get_name(args.buf)
-            if bufname == '' or vim.bo[args.buf].buftype ~= '' then
-                return
-            end
-
             local info = utils.get_project_and_file_info(args.buf)
             if info then
                 core.TimeStop({ project = info.project, file = info.file })
@@ -106,12 +78,6 @@ function M.setup_autocmds()
         group = timeGroup,
         desc = 'End Timetracking on VimLeave (general stop)',
         callback = function(args)
-            -- Prevent execution if buffer name is empty or special buffer
-            local bufname = vim.api.nvim_buf_get_name(args.buf)
-            if bufname == '' or vim.bo[args.buf].buftype ~= '' then
-                return
-            end
-
             local info = utils.get_project_and_file_info(args.buf)
             if info then
                 core.TimeStop({ project = info.project, file = info.file })


### PR DESCRIPTION
checks for empty or special buffer names are removed
from the autocmds to streamline the time tracking logic.
This simplifies the code while allowing time tracking to function
in a broader range of scenarios without unnecessary restrictions.