### PR TITLE
Feat: Implement instance lock to prevent double tracking

### DIFF
--- a/lua/maorun/time/autocmds.lua
+++ b/lua/maorun/time/autocmds.lua
@@ -8,68 +8,108 @@ function M.setup_autocmds()
 
     vim.api.nvim_create_autocmd('VimEnter', {
         group = timeGroup,
-        desc = 'Start Timetracking on VimEnter for the initial buffer',
+        desc = 'Attempt to acquire lock and start Timetracking on VimEnter for the initial buffer',
         callback = function()
-            local current_buf = vim.api.nvim_get_current_buf()
-            local info = utils.get_project_and_file_info(current_buf)
-            if info then
-                core.TimeStart({ project = info.project, file = info.file })
+            if core.acquire_instance_lock() then
+                -- vim.notify("VimEnter: Acquired lock, starting tracking.", vim.log.levels.INFO)
+                local current_buf = vim.api.nvim_get_current_buf()
+                local info = utils.get_project_and_file_info(current_buf)
+                if info then
+                    core.TimeStart({ project = info.project, file = info.file })
+                else
+                    core.TimeStart() -- Use defaults if no info
+                end
             else
-                core.TimeStart() -- Use defaults if no info
+                -- vim.notify("VimEnter: Did not acquire lock.", vim.log.levels.INFO)
             end
         end,
     })
 
     vim.api.nvim_create_autocmd('BufEnter', {
         group = timeGroup,
-        desc = 'Start Timetracking when entering a buffer',
+        desc = 'Start Timetracking when entering a buffer, if instance has lock',
         callback = function(args)
-            local info = utils.get_project_and_file_info(args.buf)
-            if info then
-                core.TimeStart({ project = info.project, file = info.file })
+            if core.has_instance_lock() then
+                -- vim.notify("BufEnter: Has lock, starting tracking for buffer.", vim.log.levels.INFO)
+                local info = utils.get_project_and_file_info(args.buf)
+                if info then
+                    core.TimeStart({ project = info.project, file = info.file })
+                else
+                    core.TimeStart()
+                end
             else
-                core.TimeStart()
+                -- vim.notify("BufEnter: No lock, not tracking for buffer.", vim.log.levels.INFO)
             end
         end,
     })
 
     vim.api.nvim_create_autocmd('FocusGained', {
         group = timeGroup,
-        desc = 'Start Timetracking when Neovim gains focus',
+        desc = 'Start Timetracking when Neovim gains focus, if instance has or can acquire lock',
         callback = function()
-            local current_buf = vim.api.nvim_get_current_buf()
-            local info = utils.get_project_and_file_info(current_buf)
-            if info then
-                core.TimeStart({ project = info.project, file = info.file })
-            else
-                core.TimeStart()
+            local acquired_now = false
+            if not core.has_instance_lock() then
+                if core.acquire_instance_lock() then
+                    -- vim.notify("FocusGained: Acquired lock now.", vim.log.levels.INFO)
+                    acquired_now = true
+                else
+                    -- vim.notify("FocusGained: Still no lock, not starting tracking.", vim.log.levels.INFO)
+                    return -- Did not acquire lock, do nothing
+                end
+            end
+            -- If we have the lock (either previously or acquired now)
+            if core.has_instance_lock() then
+                -- vim.notify("FocusGained: Has lock, starting tracking.", vim.log.levels.INFO)
+                local current_buf = vim.api.nvim_get_current_buf()
+                local info = utils.get_project_and_file_info(current_buf)
+                if info then
+                    core.TimeStart({ project = info.project, file = info.file })
+                else
+                    core.TimeStart()
+                end
             end
         end,
     })
 
     vim.api.nvim_create_autocmd('BufLeave', {
         group = timeGroup,
-        desc = 'Stop Timetracking for the buffer being left',
+        desc = 'Stop Timetracking for the buffer being left, if instance has lock',
         callback = function(args)
-            local info = utils.get_project_and_file_info(args.buf)
-            if info then
-                core.TimeStop({ project = info.project, file = info.file })
+            if core.has_instance_lock() then
+                -- vim.notify("BufLeave: Has lock, stopping tracking for buffer.", vim.log.levels.INFO)
+                local info = utils.get_project_and_file_info(args.buf)
+                if info then
+                    core.TimeStop({ project = info.project, file = info.file })
+                else
+                    core.TimeStop()
+                end
             else
-                core.TimeStop()
+                -- vim.notify("BufLeave: No lock, not stopping tracking for buffer.", vim.log.levels.INFO)
             end
         end,
     })
 
     vim.api.nvim_create_autocmd('VimLeavePre', {
         group = timeGroup,
-        desc = 'End Timetracking on VimLeave (general stop)',
+        desc = 'End Timetracking on VimLeave and release lock if owned',
         callback = function(args)
-            local info = utils.get_project_and_file_info(args.buf)
-            if info then
-                core.TimeStop({ project = info.project, file = info.file })
+            if core.has_instance_lock() then
+                -- vim.notify("VimLeavePre: Has lock, stopping tracking.", vim.log.levels.INFO)
+                local info = utils.get_project_and_file_info(args.buf) -- args.buf might be -1 or invalid here
+                -- It's safer to just call a general TimeStop if needed, or ensure TimeStop handles nil gracefully.
+                -- For now, let's assume the last active buffer's info is what we want, or default.
+                -- The current TimeStop defaults project/file if not provided, which is fine.
+                if info and info.project and info.file then
+                     core.TimeStop({ project = info.project, file = info.file })
+                else
+                     core.TimeStop() -- Stop with default/last known if any
+                end
             else
-                core.TimeStop()
+                -- vim.notify("VimLeavePre: No lock, not stopping tracking.", vim.log.levels.INFO)
             end
+            -- Always attempt to release the lock; release_instance_lock will check ownership.
+            -- vim.notify("VimLeavePre: Releasing lock.", vim.log.levels.INFO)
+            core.release_instance_lock()
         end,
     })
 end

--- a/lua/maorun/time/autocmds.lua
+++ b/lua/maorun/time/autocmds.lua
@@ -100,9 +100,9 @@ function M.setup_autocmds()
                 -- For now, let's assume the last active buffer's info is what we want, or default.
                 -- The current TimeStop defaults project/file if not provided, which is fine.
                 if info and info.project and info.file then
-                     core.TimeStop({ project = info.project, file = info.file })
+                    core.TimeStop({ project = info.project, file = info.file })
                 else
-                     core.TimeStop() -- Stop with default/last known if any
+                    core.TimeStop() -- Stop with default/last known if any
                 end
             else
                 -- vim.notify("VimLeavePre: No lock, not stopping tracking.", vim.log.levels.INFO)

--- a/lua/maorun/time/core.lua
+++ b/lua/maorun/time/core.lua
@@ -5,7 +5,7 @@ local utils = require('maorun.time.utils')
 
 local M = {}
 
-local lock_file_path = vim.fn.stdpath('run') .. "/maorun_time.lock"
+local lock_file_path = vim.fn.stdpath('run') .. '/maorun_time.lock'
 local current_pid = vim.fn.getpid()
 
 function M.acquire_instance_lock()
@@ -22,9 +22,9 @@ function M.acquire_instance_lock()
         return false -- Locked by another instance
     else
         -- Attempt to create and write PID
-        local ok, err = lock_p:write(tostring(current_pid), "w")
+        local ok, err = lock_p:write(tostring(current_pid), 'w')
         if not ok then
-            vim.notify("Failed to write lock file: " .. err, vim.log.levels.ERROR)
+            vim.notify('Failed to write lock file: ' .. err, vim.log.levels.ERROR)
             return false
         end
         -- print("Acquired lock for PID: " .. current_pid)
@@ -36,7 +36,7 @@ function M.release_instance_lock()
     local lock_p = Path:new(lock_file_path)
     if lock_p:exists() then
         local owner_pid_str = lock_p:read()
-        if owner_pid_str == nil or owner_pid_str == "" then
+        if owner_pid_str == nil or owner_pid_str == '' then
             -- Lock file is empty or unreadable, can attempt to remove or just report
             -- For safety, if we can't confirm ownership, don't delete.
             -- However, if it's empty, it's likely corrupted. Let's try removing if current PID was supposed to own it.
@@ -47,9 +47,11 @@ function M.release_instance_lock()
         end
         local owner_pid = tonumber(owner_pid_str)
         if owner_pid == current_pid then
-            local ok, err = pcall(function() lock_p:rm() end)
+            local ok, err = pcall(function()
+                lock_p:rm()
+            end)
             if not ok then
-                vim.notify("Failed to remove lock file: " .. err, vim.log.levels.ERROR)
+                vim.notify('Failed to remove lock file: ' .. err, vim.log.levels.ERROR)
             end
             -- print("Released lock for PID: " .. current_pid)
         else
@@ -62,7 +64,7 @@ function M.has_instance_lock()
     local lock_p = Path:new(lock_file_path)
     if lock_p:exists() then
         local owner_pid_str = lock_p:read()
-        if owner_pid_str == nil or owner_pid_str == "" then
+        if owner_pid_str == nil or owner_pid_str == '' then
             return false -- Unreadable or empty lock file
         end
         local owner_pid = tonumber(owner_pid_str)

--- a/lua/maorun/time/core.lua
+++ b/lua/maorun/time/core.lua
@@ -5,6 +5,72 @@ local utils = require('maorun.time.utils')
 
 local M = {}
 
+local lock_file_path = vim.fn.stdpath('run') .. "/maorun_time.lock"
+local current_pid = vim.fn.getpid()
+
+function M.acquire_instance_lock()
+    local lock_p = Path:new(lock_file_path)
+    if lock_p:exists() then
+        local owner_pid_str = lock_p:read()
+        local owner_pid = tonumber(owner_pid_str)
+        if owner_pid == current_pid then
+            return true -- Already own the lock
+        end
+        -- Basic check: if PID file exists, assume it's locked by another live instance.
+        -- More advanced: check if owner_pid is running. For now, simple check.
+        -- print("Lock file exists, owned by PID: " .. owner_pid_str)
+        return false -- Locked by another instance
+    else
+        -- Attempt to create and write PID
+        local ok, err = lock_p:write(tostring(current_pid), "w")
+        if not ok then
+            vim.notify("Failed to write lock file: " .. err, vim.log.levels.ERROR)
+            return false
+        end
+        -- print("Acquired lock for PID: " .. current_pid)
+        return true -- Lock acquired
+    end
+end
+
+function M.release_instance_lock()
+    local lock_p = Path:new(lock_file_path)
+    if lock_p:exists() then
+        local owner_pid_str = lock_p:read()
+        if owner_pid_str == nil or owner_pid_str == "" then
+            -- Lock file is empty or unreadable, can attempt to remove or just report
+            -- For safety, if we can't confirm ownership, don't delete.
+            -- However, if it's empty, it's likely corrupted. Let's try removing if current PID was supposed to own it.
+            -- This case should ideally not happen with proper acquire logic.
+            -- For now, let's be strict: only delete if PID matches.
+            -- os.remove(lock_file_path) -- Or lock_p:rm()
+            return
+        end
+        local owner_pid = tonumber(owner_pid_str)
+        if owner_pid == current_pid then
+            local ok, err = pcall(function() lock_p:rm() end)
+            if not ok then
+                vim.notify("Failed to remove lock file: " .. err, vim.log.levels.ERROR)
+            end
+            -- print("Released lock for PID: " .. current_pid)
+        else
+            -- print("Did not release lock, owned by PID: " .. owner_pid_str)
+        end
+    end
+end
+
+function M.has_instance_lock()
+    local lock_p = Path:new(lock_file_path)
+    if lock_p:exists() then
+        local owner_pid_str = lock_p:read()
+        if owner_pid_str == nil or owner_pid_str == "" then
+            return false -- Unreadable or empty lock file
+        end
+        local owner_pid = tonumber(owner_pid_str)
+        return owner_pid == current_pid
+    end
+    return false
+end
+
 function M.init(user_config)
     config_module.config =
         vim.tbl_deep_extend('force', vim.deepcopy(config_module.defaults), user_config or {})
@@ -557,5 +623,9 @@ end
 function M.get_config()
     return config_module.obj
 end
+
+M.acquire_instance_lock = M.acquire_instance_lock
+M.release_instance_lock = M.release_instance_lock
+M.has_instance_lock = M.has_instance_lock
 
 return M


### PR DESCRIPTION
Introduces a lock file mechanism to ensure that only one instance of Neovim actively performs automatic time tracking via VimEnter, FocusGained, BufEnter, and BufLeave autocommands.

- New functions in core.lua: acquire_instance_lock, release_instance_lock, has_instance_lock.
- Autocmds in autocmds.lua now use these lock functions to gate calls to TimeStart and TimeStop.
- The lock file is stored in vim.fn.stdpath('run') and contains the PID of the Neovim instance holding the lock.

This prevents multiple Neovim instances from simultaneously starting timers and creating duplicate or overlapping time entries when they are configured for automatic tracking.